### PR TITLE
[sc-32565] Explicitly set publish access config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Publish package
-        run: npm publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Per [Publishing scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages):

> By default, scoped packages are published with private visibility. To publish a scoped package with public visibility, use `npm publish --access public`.

I think we can probably just cut `v0.1.1` to keep things clean.