### PR TITLE
[sc-23218] Generalize middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,9 @@ The **Results Validator** ensures that the pipeline has fulfilled the interface 
 
 ## Middleware
 
-If **Middleware** is specified, it will be run on the specified stage lifecycle event(s) for each stage in the pipeline.
+If **Middleware** is specified, it will be wrapped around each stage in the pipeline. This follows [a pattern similar to Express](https://expressjs.com/en/guide/using-middleware.html). Each middleware is called in the order it is specified and includes a `next()` to call the next middleware/stage.
 
-| Stage Event       | Description                        |
-| ----------------- | ---------------------------------- |
-| `onStageStart`    | Runs before each stage is executed |
-| `onStageComplete` | Runs after each stage is executed  |
-
-Middleware is specified as an object with middleware callbacks mapped to at least one of the above event keys. A middleware callback is provided the following attributes:
+A middleware callback is provided the following attributes:
 
 | Parameter      | Description                                                                   |
 | -------------- | ----------------------------------------------------------------------------- |
@@ -102,6 +97,7 @@ Middleware is specified as an object with middleware callbacks mapped to at leas
 | `results`      | A read-only set of results returned by stages so far                          |
 | `stageNames`   | An array of the names of the methods that make up the current pipeline stages |
 | `currentStage` | The name of the current pipeline stage                                        |
+| `next`         | Calls the next middleware in the stack (or the stage if none)                 |
 
 See the [LogStageMiddlewareFactory](./src/middleware/logStageMiddlewareFactory.ts) for a simple middleware implementation. It is wrapped in a factory method so a log method can be properly injected.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
+    "dev": "tsc --noEmit --watch",
     "prepack": "npm run build",
     "build": "tsc --project tsconfig.build.json",
     "eslint": "eslint --ext .js,.ts --cache --cache-location=node_modules/.cache/eslint --cache-strategy content .",

--- a/src/__mocks__/TestPipeline.ts
+++ b/src/__mocks__/TestPipeline.ts
@@ -1,6 +1,7 @@
 import { last } from "lodash";
-import {
+import type {
   PipelineInitializer,
+  PipelineMiddleware,
   PipelineResultValidator,
   PipelineStage,
 } from "../types";
@@ -19,6 +20,12 @@ export interface TestPipelineResults {
 }
 
 export type TestStage = PipelineStage<
+  TestPipelineArguments,
+  TestPipelineContext,
+  TestPipelineResults
+>;
+
+export type TestMiddleware = PipelineMiddleware<
   TestPipelineArguments,
   TestPipelineContext,
   TestPipelineResults
@@ -82,7 +89,7 @@ export const errorStage: TestStage = () => {
  */
 export const testPipelineResultValidator: PipelineResultValidator<
   TestPipelineResults
-> = (results) => {
+> = (results): results is TestPipelineResults => {
   // false if sum is not a number
   if (typeof results.sum !== "number") {
     return false;

--- a/src/buildPipeline.ts
+++ b/src/buildPipeline.ts
@@ -7,7 +7,6 @@ import type {
   PipelineMiddleware,
   PipelineResultValidator,
   PipelineStage,
-  PipelineStageResult,
 } from "./types";
 
 interface BuildPipelineInput<
@@ -57,7 +56,7 @@ export function buildPipeline<
       const wrapMiddleware = (
         middleware: PipelineMiddleware<A, C, R>,
         currentStage: string,
-        next: () => PipelineStageResult<R>,
+        next: () => Promise<Partial<R>>,
       ) => {
         return () => {
           return middleware({
@@ -73,7 +72,7 @@ export function buildPipeline<
 
       for (const stage of stages) {
         // initialize next() with the stage itself
-        let next = () => stage(context, metadata);
+        let next = () => stage(context, metadata) as Promise<Partial<R>>;
 
         // wrap stage with middleware such that the first middleware is the outermost function
         for (const middleware of reversedMiddleware) {

--- a/src/buildPipeline.ts
+++ b/src/buildPipeline.ts
@@ -1,15 +1,13 @@
-import { compact, merge } from "lodash";
+import { merge } from "lodash";
 import { PipelineError } from "./error/PipelineError";
-import {
+import type {
   Pipeline,
   PipelineInitializer,
   PipelineMetadata,
   PipelineMiddleware,
-  PipelineMiddlewareCallable,
-  PipelineMiddlewareEventType,
-  PipelineMiddlewarePayload,
   PipelineResultValidator,
   PipelineStage,
+  PipelineStageResult,
 } from "./types";
 
 interface BuildPipelineInput<
@@ -21,7 +19,7 @@ interface BuildPipelineInput<
   initializer: PipelineInitializer<C, A>;
   stages: PipelineStage<A, C, R>[];
   resultsValidator: PipelineResultValidator<R>;
-  middleware?: PipelineMiddleware[];
+  middleware?: PipelineMiddleware<A, C, R>[];
 }
 
 /**
@@ -36,7 +34,7 @@ export function buildPipeline<
   initializer,
   stages,
   resultsValidator,
-  middleware = [],
+  middleware: middlewares = [],
 }: BuildPipelineInput<A, C, R>): Pipeline<A, R> {
   return async (args) => {
     const results: Partial<R> = {};
@@ -55,78 +53,55 @@ export function buildPipeline<
       const context = await initializer(args);
       maybeContext = context;
 
-      const buildMiddlewarePayload = (
+      const reversedMiddleware = [...middlewares].reverse();
+      const wrapMiddleware = (
+        middleware: PipelineMiddleware<A, C, R>,
         currentStage: string,
-      ): PipelineMiddlewarePayload<A, C, R> => ({
-        context,
-        metadata,
-        results,
-        stageNames,
-        currentStage,
-      });
+        next: () => PipelineStageResult<R>,
+      ) => {
+        return () => {
+          return middleware({
+            context,
+            metadata,
+            results,
+            stageNames,
+            currentStage,
+            next,
+          });
+        };
+      };
 
       for (const stage of stages) {
-        await executeMiddlewareForEvent(
-          "onStageStart",
-          middleware,
-          buildMiddlewarePayload(stage.name),
-        );
+        // initialize next() with the stage itself
+        let next = () => stage(context, metadata);
 
-        const stageResults = await stage(context, metadata);
+        // wrap stage with middleware such that the first middleware is the outermost function
+        for (const middleware of reversedMiddleware) {
+          next = wrapMiddleware(middleware, stage.name, next);
+        }
+
+        // invoke middleware-wrapped stage
+        const stageResults = await next();
 
         // if the stage returns results, merge them onto the results object
         if (stageResults) {
           merge(results, stageResults);
         }
-
-        await executeMiddlewareForEvent(
-          "onStageComplete",
-          [...middleware].reverse(),
-          buildMiddlewarePayload(stage.name),
-        );
       }
 
-      if (!isValidResult(results, resultsValidator)) {
+      if (!resultsValidator(results)) {
         throw new Error("Results from pipeline failed validation");
       }
 
       return results;
-    } catch (e) {
+    } catch (cause) {
       throw new PipelineError(
-        `${String(e)}`,
+        String(cause),
         maybeContext,
         results,
         metadata,
-        e,
+        cause,
       );
     }
   };
-}
-
-async function executeMiddlewareForEvent<
-  A extends object,
-  C extends object,
-  R extends object,
->(
-  event: PipelineMiddlewareEventType,
-  middleware: PipelineMiddleware[],
-  payload: PipelineMiddlewarePayload<A, C, R>,
-) {
-  const handlers = compact<PipelineMiddlewareCallable<object, object, object>>(
-    middleware.map((m) => m[event]),
-  );
-
-  for (const handler of handlers) {
-    await handler(payload);
-  }
-}
-
-/**
- * Wraps the provided validator in a type guard
- */
-function isValidResult<R extends object>(
-  result: Partial<R>,
-  validator: PipelineResultValidator<R>,
-): result is R {
-  return validator(result);
 }

--- a/src/middleware/logStageMiddlewareFactory.ts
+++ b/src/middleware/logStageMiddlewareFactory.ts
@@ -1,15 +1,20 @@
 import { PipelineMiddleware } from "../types";
 
 /**
- * A simple implementation of Pipeline middleware that logs when each stage begins and finishes
+ * A simple implementation of Pipeline middleware that logs the duration of each stage
  */
 export const logStageMiddlewareFactory = (
   logger: (msg: string) => void = console.log,
-): PipelineMiddleware => ({
-  onStageStart: ({ metadata, currentStage }) => {
-    logger(`[${metadata.name}] starting ${currentStage}...`);
-  },
-  onStageComplete: ({ metadata, currentStage }) => {
-    logger(`[${metadata.name}] ${currentStage} completed`);
-  },
-});
+): PipelineMiddleware => {
+  return async ({ metadata, currentStage, next }) => {
+    const started = performance.now();
+
+    try {
+      return await next();
+    } finally {
+      logger(
+        `[${metadata.name}] ${currentStage} completed in ${performance.now() - started}ms`,
+      );
+    }
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export type PipelineMiddleware<
   A extends object = object,
   C extends object = object,
   R extends object = object,
-> = (payload: PipelineMiddlewarePayload<A, C, R>) => PipelineStageResult<R>;
+> = (payload: PipelineMiddlewarePayload<A, C, R>) => Promise<Partial<R>>;
 
 /**
  * The payload that gets passed to each `PipelineMiddleware`
@@ -68,5 +68,5 @@ export interface PipelineMiddlewarePayload<
   results: Readonly<Partial<R>>;
   stageNames: string[];
   currentStage: string;
-  next: () => PipelineStageResult<R>;
+  next: () => Promise<Partial<R>>;
 }


### PR DESCRIPTION
## Summary

* Add `dev` npm script
* Move `PipelineMiddleware` object to Express-like function with `next()` argument
* Update `logStageMiddlewareFactory` with timing information
* Update `PipelineResultValidator` return type to type predicate from boolean

## Release Notes

We'll want to cut `v1.0.0` as this is a breaking change

### Breaking Changes

* `PipelineMiddleware` is now an async function that is passed an [Express-like](https://expressjs.com/en/guide/using-middleware.html) `next` function. The `next()` function returns a promise that resolves with the stage result which the middleware is expected to return. For example:

   #### Before

    ```ts
    const logStageMiddleware: PipelineMiddleware = {
      onStageStart: ({ metadata, currentStage }) => {
        console.log(`[${metadata.name}] starting ${currentStage}...`);
      },
      onStageComplete: ({ metadata, currentStage }) => {
        console.log(`[${metadata.name}] ${currentStage} completed`);
      },
    };
    ```

   #### After

    ```ts
    const logStageMiddleware: PipelineMiddleware = async ({
      metadata,
      currentStage,
      next,
    }) => {
      try {
        console.log(`[${metadata.name}] starting ${currentStage}...`);
    
        return await next();
      } finally {
        console.log(`[${metadata.name}] ${currentStage} completed`);
      }
    };
    ```

* `PipelineResultValidator` type now takes a `Readonly` argument, and its return type is a [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates):

    ```ts
    type PipelineResultValidator<R extends object> = (
      results: Readonly<Partial<R>>,
    ) => results is R;
    ```

## Checklist

- [x] Update documentation