### PR TITLE
[SC-32565] Update import locations

### DIFF
--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,0 +1,1 @@
+export { PipelineError } from "./PipelineError";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
+export * from "middleware";
 export { buildPipeline } from "./buildPipeline";
+export * from "./error";
+export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from "middleware";
-export { buildPipeline } from "./buildPipeline";
+export * from "./buildPipeline";
 export * from "./error";
+export * from "./middleware";
 export * from "./types";

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export { logStageMiddlewareFactory } from "./logStageMiddlewareFactory";


### PR DESCRIPTION
This PR adds the main importable types to `index.ts` in order to avoid imports like:

```typescript
import { PipelineResultValidator } from "@fieldguide/pipeline/build/types";
```