### PR TITLE
[43991] add rollback to pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ The **Initializer** is a method that takes in the pipeline's arguments and produ
 
 **Stages** are the independent steps in the process chain. They are processed synchronously (one at a time, in order) until the end of the chain is reached.
 
+As of version `0.1.0` stages can be one of two types
+* PipelineStage
+* PipelineStageWithRollback
+
+`PipelineStageWithRollback` adds the ability for the user to define a `rollback` function, which should undo changes made by the `execute` function.
+
+The pipeline can support processing a collection of stages of either type.
+
 ### Stage Arguments
 
 The following arguments are provided to a stage when it is executed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fieldguide/pipeline",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fieldguide/pipeline",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fieldguide/pipeline",
   "description": "A toolkit to easily build synchronous process pipelines in TypeScript/JavaScript",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/src/__tests__/buildPipeline.test.ts
+++ b/src/__tests__/buildPipeline.test.ts
@@ -1,14 +1,17 @@
 import { logStageMiddlewareFactory } from "middleware/logStageMiddlewareFactory";
 import {
+  EXTERNAL_STATE,
   TestMiddleware,
   TestPipelineArguments,
   TestPipelineContext,
   TestPipelineResults,
   TestStage,
+  TestStageWithRollback,
   additionStage,
   errorStage,
   initializer,
   returnHistoryResult,
+  stageWithRollback,
   testPipelineResultValidator,
 } from "../__mocks__/TestPipeline";
 import { buildPipeline } from "../buildPipeline";
@@ -27,6 +30,12 @@ const successfulStages: TestStage[] = [
 const partialResultsStages: TestStage[] = [additionStage, returnSumResult];
 
 const errorStages: TestStage[] = [errorStage, returnHistoryResult];
+
+const stagesWithRollback: (TestStage | TestStageWithRollback)[] = [
+  additionStage,
+  stageWithRollback,
+  errorStage,
+];
 
 describe("buildPipeline", () => {
   describe("when running a simple pipeline", () => {
@@ -98,10 +107,23 @@ describe("buildPipeline", () => {
       ]);
     });
   });
+
+  describe("when using a pipeline stage that can rollback", () => {
+    it("should allow a stage to undo the changes it made ", async () => {
+      try {
+        await runPipelineForStages(stagesWithRollback);
+      } catch {
+        // swallow error in order to confirm rollback functionality
+      }
+
+      // confirm that we rolled back to initial value of zero
+      expect(EXTERNAL_STATE.value).toEqual(0);
+    });
+  });
 });
 
 function runPipelineForStages(
-  stages: TestStage[],
+  stages: (TestStage | TestStageWithRollback)[],
   middleware: TestMiddleware[] = [],
 ) {
   const pipeline = buildPipeline<

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,18 @@ export type PipelineStage<
 > = (context: C, metadata: PipelineMetadata<A>) => PipelineStageResult<R>;
 
 /**
+ * A pipeline stage that has the ability to rollback changes made with the `execute` function
+ */
+export interface PipelineStageWithRollback<
+  A extends object,
+  C extends object,
+  R extends object,
+> {
+  execute: PipelineStage<A, C, R>;
+  rollback: (context: C, metadata: PipelineMetadata<A>) => Promise<void> | void;
+}
+
+/**
  * Optional partial result that gets merged with results from other stages
  */
 export type PipelineStageResult<R extends object> =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+import { PipelineStage, PipelineStageWithRollback } from "types";
+
+export function isPipelineStageWithRollback<
+  A extends object,
+  C extends object,
+  R extends object,
+>(
+  stage: PipelineStage<A, C, R> | PipelineStageWithRollback<A, C, R>,
+): stage is PipelineStageWithRollback<A, C, R> {
+  return (stage as PipelineStageWithRollback<A, C, R>).rollback !== undefined;
+}


### PR DESCRIPTION
Ticket: https://app.shortcut.com/fieldguide/story/43991/add-rollback-to-pipelines

Add new stage type that has a `rollback` function to undo changes made during that stage.

Bumped the version a minor version to 0.1.0 (no breaking changes introduced).
