### PR TITLE
[sc-44597] Support optional stage name property

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ As of version `0.1.0` stages can be one of two types
 - PipelineStageConfiguration
 
 `PipelineStageConfiguration` adds the ability for the user to define a `rollback` function, which should undo changes made by the `execute` function.
+It also allows providing an optional `name` property for debugging/logging purposes.
+Defaults to `Stage ${0..n}` based on the index of the stage in the pipeline.
 
 The pipeline can support processing a collection of stages of either type.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fieldguide/pipeline",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fieldguide/pipeline",
-      "version": "0.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fieldguide/pipeline",
   "description": "A toolkit to easily build synchronous process pipelines in TypeScript/JavaScript",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fieldguide/pipeline",
   "description": "A toolkit to easily build synchronous process pipelines in TypeScript/JavaScript",
-  "version": "1.2.0",
+  "version": "0.1.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/src/__mocks__/TestPipeline.ts
+++ b/src/__mocks__/TestPipeline.ts
@@ -96,10 +96,12 @@ export const errorStage: TestStage = () => {
  */
 export function generateStageWithRollback(
   rollbackFunction: () => Promise<void> | void,
+  name?: string,
 ): TestStageWithRollback {
   return {
     execute: noop,
     rollback: rollbackFunction,
+    name: name,
   };
 }
 

--- a/src/buildPipeline.ts
+++ b/src/buildPipeline.ts
@@ -96,6 +96,7 @@ export function buildPipeline<
 
         // wrap stage with middleware such that the first middleware is the outermost function
         for (const middleware of reversedMiddleware) {
+          // A stage name for the current index is assured to exist given it was built using the same collection we're iterating over now
           next = wrapMiddleware(middleware, stageNames[idx]!, next);
         }
 

--- a/src/buildPipeline.ts
+++ b/src/buildPipeline.ts
@@ -59,6 +59,7 @@ export function buildPipeline<
 
         return {
           execute: stage,
+          name: stage.name,
         };
       });
 
@@ -66,7 +67,7 @@ export function buildPipeline<
 
     try {
       const stageNames: string[] = stageConfigurations.map(
-        (s) => s.execute.name,
+        (s, idx) => s.name || `Stage ${idx}`,
       );
       maybeContext = context;
 
@@ -88,14 +89,14 @@ export function buildPipeline<
         };
       };
 
-      for (const stage of stageConfigurations) {
+      for (const [idx, stage] of stageConfigurations.entries()) {
         // initialize next() with the stage itself
         let next = () =>
           stage.execute(context, metadata) as Promise<Partial<R>>;
 
         // wrap stage with middleware such that the first middleware is the outermost function
         for (const middleware of reversedMiddleware) {
-          next = wrapMiddleware(middleware, stage.execute.name, next);
+          next = wrapMiddleware(middleware, stageNames[idx]!, next);
         }
 
         // Add stage to a stack that can be rolled back if necessary

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,15 +15,17 @@ export type PipelineStage<
 > = (context: C, metadata: PipelineMetadata<A>) => PipelineStageResult<R>;
 
 /**
- * A more explicit configuration for a pipeline stage
- * * execute: the function that executes the stage (identical to `PipelineStage`)
- * * rollback: the function that rolls back any changes made within `execute` should an error occur
+ * A more explicit configuration for a pipeline stage:
+ * * name: the name of the stage for debugging/logging purposes. Defaults to `Stage ${idx}`.
+ * * execute: the function that executes the stage (identical to {@link PipelineStage}).
+ * * rollback: the function that rolls back any changes made within `execute` should an error occur.
  */
 export interface PipelineStageConfiguration<
   A extends object,
   C extends object,
   R extends object,
 > {
+  name?: string;
   execute: PipelineStage<A, C, R>;
   rollback?: (
     context: C,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export type PipelineStage<
 
 /**
  * A more explicit configuration for a pipeline stage:
- * * name: the name of the stage for debugging/logging purposes. Defaults to `Stage ${idx}`.
+ * * name: the name of the stage for debugging/logging purposes. Defaults to `Stage ${0..n}` based on the index of the stage in the pipeline.
  * * execute: the function that executes the stage (identical to {@link PipelineStage}).
  * * rollback: the function that rolls back any changes made within `execute` should an error occur.
  */


### PR DESCRIPTION
* Add optional name property to `PipelineStageConfiguration`
* Falls back on formatted index number if not provided
  * E.g. `Stage 0`
* Bump version to match soon to be GH release tag 
