### PR TITLE
[sc-50937] Add action-lint CI on pipeline

### DIFF
--- a/.github/workflows/action-lint.yaml
+++ b/.github/workflows/action-lint.yaml
@@ -1,0 +1,8 @@
+name: Action Lint
+on:
+  pull_request:
+    paths:
+      - .github/**/*.ya?ml
+jobs:
+  ci:
+    uses: fieldguide/github-actions-common/.github/workflows/action-lint.yaml@main


### PR DESCRIPTION
# Summary

## Description
As an engineer, I want to know that my github actions are valid before implementing them. 

https://github.com/rhysd/actionlint
Should run on all github actions to detect staticly detectable errors. 

## AC
* All repos should have action lint on it for their github action manifests

## Commits



## Dependencies
–

## Compatibility

- [ ] Backwards compatible

## Testing

## Checklist
