### PR TITLE
[SC-58776] Publish Pipeline package to NPM and Github

### DIFF
--- a/.github/workflows/action-lint.yaml
+++ b/.github/workflows/action-lint.yaml
@@ -1,8 +1,15 @@
+# copied from https://github.com/Fieldguide/github-actions-common/blob/main/.github/workflows/action-lint.yaml
+
 name: Action Lint
 on:
   pull_request:
-    paths:
-      - .github/**/*.ya?ml
+  workflow_call:
 jobs:
-  ci:
-    uses: fieldguide/github-actions-common/.github/workflows/action-lint.yaml@main
+  actionlint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1.65.2
+        with:
+          actionlint_flags: "-shellcheck= "
+          fail_level: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,11 @@ env:
   SLACK_DEPLOY_ERROR_REACTION: ${{ vars.SLACK_DEPLOY_ERROR_REACTION_PRODUCTION }}
 
 jobs:
-  publish:
+  start:
     runs-on: ubuntu-latest
+    outputs:
+      thread_ts: ${{ steps.slack.outputs.ts }}
+      version: ${{ steps.version.outputs.value }}
     steps:
       - name: Post to Slack
         uses: Fieldguide/action-slack-deploy-pipeline@v2
@@ -28,8 +31,15 @@ jobs:
         id: version
         run: echo "value=${GITHUB_REF#refs/*/v}" >> $GITHUB_OUTPUT
 
+  publish-npm:
+    needs: start
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Update npm package version for build / publishing
-        run: npm version ${{ steps.version.outputs.value }} --no-git-tag-version
+        run: npm version ${{ needs.start.outputs.version }} --no-git-tag-version
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -47,9 +57,43 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-github:
+    needs: start
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Update npm package version for build / publishing
+        run: npm version ${{ needs.start.outputs.version }} --no-git-tag-version
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Publish package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  finish:
+    needs:
+      - start
+      - publish-npm
+      - publish-github
+    runs-on: ubuntu-latest
+    steps:
       - name: "Post to Slack"
         uses: Fieldguide/action-slack-deploy-pipeline@v2
         if: always()
         with:
-          thread_ts: ${{ steps.slack.outputs.ts }}
+          thread_ts: ${{ needs.start.outputs.thread_ts }}
           conclusion: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,6 @@ jobs:
         uses: Fieldguide/action-slack-deploy-pipeline@v2
         id: slack
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Parse version
         id: version
         run: echo "value=${GITHUB_REF#refs/*/v}" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: "Publish to npm"
+name: "Publish package"
 
 on:
   release:


### PR DESCRIPTION
# Overview

Our internal packages configure the `@fieldguide` namespace to pull from Github for packages like those in https://github.com/fieldguide/js-common.

This causes problems when we also want to access public packages under this namespace. It leads to strange situations like [this Action Server NPM configuration](https://github.com/Fieldguide/action-server/blob/master/.npmrc#L3-L4).

By publishing the Pipeline package to both NPM and Github Packages, it should allow other Fieldguide repos (e.g. Action Server) to successfully pull the Pipeline package from the Github repository instead of the NPM repository.
